### PR TITLE
Support using connection string authentication for azure storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We use *breaking :warning:* to mark changes that are not backward compatible (re
 - [#41](https://github.com/thanos-io/objstore/pull/41) S3: Support S3 session token.
 - [#43](https://github.com/thanos-io/objstore/pull/43) filesystem: abort filesystem bucket operations if the context has been cancelled
 - [#44](https://github.com/thanos-io/objstore/pull/44) Add new metric to count total number of fetched bytes from bucket
+- [#51](https://github.com/thanos-io/objstore/pull/51) azure: Support using connection string authentication.
 
 ### Changed
 - [#38](https://github.com/thanos-io/objstore/pull/38) *: Upgrade minio-go version to `v7.0.45`.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ type Bucket interface {
 	Upload(ctx context.Context, name string, r io.Reader) error
 
 	// Delete removes the object with the given name.
-	// If object does not exists in the moment of deletion, Delete should throw error.
+	// If object does not exist in the moment of deletion, Delete should throw error.
 	Delete(ctx context.Context, name string) error
 
 ```
@@ -152,6 +152,7 @@ config:
   insecure: false
   signature_version2: false
   secret_key: ""
+  session_token: ""
   put_user_metadata: {}
   http_config:
     idle_conn_timeout: 1m30s
@@ -416,6 +417,7 @@ type: AZURE
 config:
   storage_account: ""
   storage_account_key: ""
+  storage_connection_string: ""
   container: ""
   endpoint: ""
   user_assigned_id: ""
@@ -450,6 +452,8 @@ prefix: ""
 If `msi_resource` is used, authentication is done via system-assigned managed identity. The value for Azure should be `https://<storage-account-name>.blob.core.windows.net`.
 
 If `user_assigned_id` is used, authentication is done via user-assigned managed identity. When using `user_assigned_id` the `msi_resource` defaults to `https://<storage_account>.<endpoint>`
+
+If `storage_connection_string` is set, the values of `storage_account` and `endpoint` values will not be used. Use this method over `storage_account_key` if you need to authenticate via a SAS token.
 
 The generic `max_retries` will be used as value for the `pipeline_config`'s `max_tries` and `reader_config`'s `max_retry_requests`. For more control, `max_retries` could be ignored (0) and one could set specific retry values.
 

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -44,15 +44,16 @@ var DefaultConfig = Config{
 
 // Config Azure storage configuration.
 type Config struct {
-	StorageAccountName string             `yaml:"storage_account"`
-	StorageAccountKey  string             `yaml:"storage_account_key"`
-	ContainerName      string             `yaml:"container"`
-	Endpoint           string             `yaml:"endpoint"`
-	UserAssignedID     string             `yaml:"user_assigned_id"`
-	MaxRetries         int                `yaml:"max_retries"`
-	ReaderConfig       ReaderConfig       `yaml:"reader_config"`
-	PipelineConfig     PipelineConfig     `yaml:"pipeline_config"`
-	HTTPConfig         exthttp.HTTPConfig `yaml:"http_config"`
+	StorageAccountName      string             `yaml:"storage_account"`
+	StorageAccountKey       string             `yaml:"storage_account_key"`
+	StorageConnectionString string             `yaml:"storage_connection_string"`
+	ContainerName           string             `yaml:"container"`
+	Endpoint                string             `yaml:"endpoint"`
+	UserAssignedID          string             `yaml:"user_assigned_id"`
+	MaxRetries              int                `yaml:"max_retries"`
+	ReaderConfig            ReaderConfig       `yaml:"reader_config"`
+	PipelineConfig          PipelineConfig     `yaml:"pipeline_config"`
+	HTTPConfig              exthttp.HTTPConfig `yaml:"http_config"`
 
 	// Deprecated: Is automatically set by the Azure SDK.
 	MSIResource string `yaml:"msi_resource"`
@@ -74,6 +75,14 @@ func (conf *Config) validate() error {
 	var errMsg []string
 	if conf.UserAssignedID != "" && conf.StorageAccountKey != "" {
 		errMsg = append(errMsg, "user_assigned_id cannot be set when using storage_account_key authentication")
+	}
+
+	if conf.UserAssignedID != "" && conf.StorageConnectionString != "" {
+		errMsg = append(errMsg, "user_assigned_id cannot be set when using storage_connection_string authentication")
+	}
+
+	if conf.StorageAccountKey != "" && conf.StorageConnectionString != "" {
+		errMsg = append(errMsg, "storage_account_key and storage_connection_string cannot both be set")
 	}
 
 	if conf.StorageAccountName == "" {

--- a/providers/azure/azure_test.go
+++ b/providers/azure/azure_test.go
@@ -132,6 +132,16 @@ container: "MyContainer"`),
 		wantFailParse:    false,
 		wantFailValidate: false,
 	},
+	{
+		name: "Valid User Assigned and Connection String set",
+		config: []byte(`storage_account: "myAccount"
+storage_account_key: ""
+user_assigned_id: "1234-56578678-655"
+storage_connection_string: "myConnectionString"
+container: "MyContainer"`),
+		wantFailParse:    false,
+		wantFailValidate: true,
+	},
 }
 
 func TestConfig_validate(t *testing.T) {

--- a/providers/azure/helpers.go
+++ b/providers/azure/helpers.go
@@ -38,6 +38,16 @@ func getContainerClient(conf Config) (*container.Client, error) {
 			Transport: &http.Client{Transport: dt},
 		},
 	}
+
+	// Use connection string if set
+	if conf.StorageConnectionString != "" {
+		containerClient, err := container.NewClientFromConnectionString(conf.StorageConnectionString, conf.ContainerName, opt)
+		if err != nil {
+			return nil, err
+		}
+		return containerClient, nil
+	}
+
 	containerURL := fmt.Sprintf("https://%s.%s/%s", conf.StorageAccountName, conf.Endpoint, conf.ContainerName)
 
 	// Use shared keys if set


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "s3:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos Objstore <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/objstore/pull/<PR-id>
    <Component> Component affected by your changes such as s3, azure, cos.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
